### PR TITLE
Feature/36 37 invalid inputs and categorical

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -46,7 +46,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]  # , macos-latest, windows-latest]
+        # see https://github.com/actions/setup-python/issues/544
+        os: [ ubuntu-20.04 ]  # ubuntu-latest, macos-latest, windows-latest]
         # all nox sessions: manually > dynamically from previous job
         # nox_session: ["tests-2.7", "tests-3.7"]
         nox_session: ${{ fromJson(needs.list_nox_test_sessions.outputs.matrix) }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 0.6.4 - Bugfixes
+
+ - Replaced usage of deprecated `scipy_mode`. Fixed  [#39](https://github.com/python-qds/qdscreen/issues/39)
+ - Fixed `ValueError: invalid literal for int() with base 10` in `predict_qd`. Fixed [#40](https://github.com/python-qds/qdscreen/issues/40)
+ - Added input validators to raise human-readable error messages when the input is not correct. Fixes [#37](https://github.com/python-qds/qdscreen/issues/37)
+ - Fixed `AttributeError: module 'numpy' has no attribute 'object'.`. Fixes [#38](https://github.com/python-qds/qdscreen/issues/38)
+
 ### 0.6.3 - Bugfixes
 
  - Fixed `ValueError` with recent versions of `SciPy`, due to usage of sparse arrays with object dtype. Fixes [#31](https://github.com/python-qds/qdscreen/issues/31)

--- a/qdscreen/main.py
+++ b/qdscreen/main.py
@@ -34,13 +34,14 @@ def _add_names_to_parents_idx_series(parents):
 
 class QDForest(object):
     """A quasi-deterministic forest returned by `qd_screen`"""
-    __slots__ = ('_adjmat',         # a square numpy array or pandas DataFrame containing the adjacency matrix (parent->child)
-                 '_parents',        # a 1d np array or a pandas Series relating each child to its parent index or -1 if a root
-                 'is_nparray',      # a boolean indicating if this was built from numpy array (and not pandas dataframe)
-                 '_roots_mask',     # a 1d np array or pd Series containing a boolean mask for root variables
-                 '_roots_wc_mask',  # a 1d np array or pd Series containing a boolean mask for root with children
-                 'stats'            # an optional `Entropies` object stored for debug
-                 )
+    __slots__ = (
+        '_adjmat',         # a square np array or pd DataFrame containing the adjacency matrix (parent->child)
+        '_parents',        # a 1d np array or a pandas Series relating each child to its parent index or -1 if a root
+        'is_nparray',      # a boolean indicating if this was built from numpy array (and not pandas dataframe)
+        '_roots_mask',     # a 1d np array or pd Series containing a boolean mask for root variables
+        '_roots_wc_mask',  # a 1d np array or pd Series containing a boolean mask for root with children
+        'stats'            # an optional `Entropies` object stored for debug
+    )
 
     def __init__(self,
                  adjmat=None,    # type: Union[np.ndarray, pd.DataFrame]
@@ -129,13 +130,13 @@ class QDForest(object):
     @property
     def adjmat_ar(self):
         """The adjacency matrix as a 2D numpy array"""
-        return self.adjmat if self.is_nparray else  self.adjmat.values
+        return self.adjmat if self.is_nparray else self.adjmat.values
 
     @property
     def adjmat(self):
         """The adjacency matrix as a pandas DataFrame or a 2D numpy array"""
         if self._adjmat is None:
-            # compute adjmat from parents.
+            # compute adjmat from parents and cache it
             n = self.nb_vars
             adjmat = np.zeros((n, n), dtype=bool)
             # from https://stackoverflow.com/a/46018613/7262247

--- a/qdscreen/selector.py
+++ b/qdscreen/selector.py
@@ -17,7 +17,41 @@ class InvalidDataInputError(ValueError):
 def _get_most_common_value(x):
     # From https://stackoverflow.com/a/47778607/7262247
     # `scipy_mode` is the most robust to the various pitfalls (nans, ...)
-    return scipy_mode(x)[0][0]
+    # but they will deprecate it
+    # return scipy_mode(x, nan_policy=None)[0][0]
+    res = x.mode(dropna=True)
+    if len(res) == 0:
+        return np.nan
+    else:
+        return res
+
+
+class ParentChildMapping:
+    __slots__ = ('_mapping_dct', '_otypes')
+
+    def __init__(
+        self,
+        mapping_dct  # type: Dict
+    ):
+        self._mapping_dct = mapping_dct
+        # Find the correct otype to use in the vectorized operation
+        self._otypes = [np.array(mapping_dct.values()).dtype]
+
+    def predict_child_from_parent_ar(
+        self,
+        parent_values  # type: np.ndarray
+    ):
+        """For numpy"""
+        # apply the learned map efficienty https://stackoverflow.com/q/16992713/7262247
+        return np.vectorize(self._mapping_dct.__getitem__, otypes=self._otypes)(parent_values)
+
+    def predict_child_from_parent(
+        self,
+        parent_values  # type: pd.DataFrame
+    ):
+        """For pandas"""
+        # See https://stackoverflow.com/questions/47930052/pandas-vectorized-lookup-of-dictionary
+        return parent_values.map(self._mapping_dct)
 
 
 class QDSelectorModel(object):
@@ -118,8 +152,11 @@ class QDSelectorModel(object):
                 pc_df = pd.DataFrame(X[:, (parent, child)], columns=["parent", "child"])
                 levels_mapping_df = pc_df.groupby(by="parent").agg(_get_most_common_value)
 
+                # Init the dict for parent if it does not exit
                 maps.setdefault(parent, dict())
-                maps[parent][child] = levels_mapping_df.iloc[:, 0].to_dict()
+
+                # Fill the parent-child item with the mapping object
+                maps[parent][child] = ParentChildMapping(levels_mapping_df.iloc[:, 0].to_dict())
 
         else:
             assert isinstance(X, pd.DataFrame)
@@ -139,8 +176,11 @@ class QDSelectorModel(object):
                 pc_df = pd.DataFrame(X_ar[:, (parent, child)], columns=["parent", "child"])
                 levels_mapping_df = pc_df.groupby("parent").agg(_get_most_common_value)
 
+                # Init the dict for parent if it does not exit
                 maps.setdefault(parent, dict())
-                maps[parent][child] = levels_mapping_df.iloc[:, 0].to_dict()
+
+                # Fill the parent-child item with the mapping object
+                maps[parent][child] = ParentChildMapping(levels_mapping_df.iloc[:, 0].to_dict())
 
     def remove_qd(self,
                   X,             # type: Union[np.ndarray, pd.DataFrame]
@@ -228,8 +268,7 @@ class QDSelectorModel(object):
 
             # walk the tree from the roots
             for _, parent, child in forest.walk_arcs():
-                # apply the learned map efficienty https://stackoverflow.com/q/16992713/7262247
-                X[:, child] = np.vectorize(self._maps[parent][child].__getitem__)(X[:, parent])
+                X[:, child] = self._maps[parent][child].predict_child_from_parent_ar(X[:, parent])
         else:
             if not inplace:
                 X = X.copy()
@@ -237,8 +276,7 @@ class QDSelectorModel(object):
             # walk the tree from the roots
             varnames = forest.varnames
             for _, parent, child in forest.walk_arcs(names=False):
-                # apply the learned map efficienty https://stackoverflow.com/q/16992713/7262247
-                X.loc[:, varnames[child]] = np.vectorize(self._maps[parent][child].__getitem__)(X.loc[:, varnames[parent]])
+                X.loc[:, varnames[child]] = self._maps[parent][child].predict_child_from_parent(X.loc[:, varnames[parent]])
 
         if not inplace:
             return X

--- a/qdscreen/sklearn.py
+++ b/qdscreen/sklearn.py
@@ -89,7 +89,7 @@ class QDScreen(SelectorMixin, BaseEstimator):
         self
         """
         X = self._validate_data(X, accept_sparse=False,  #('csr', 'csc'),
-                                dtype=np.object,
+                                dtype=object,
                                 force_all_finite='allow-nan')
 
         # if hasattr(X, "toarray"):   # sparse matrix

--- a/qdscreen/tests/test_core.py
+++ b/qdscreen/tests/test_core.py
@@ -325,8 +325,11 @@ def test_issue_40_nan_then_str():
         "bar": [np.nan, "B"]
     })
     qd_forest = qd_screen(df)
+    assert list(qd_forest.roots) == ["foo"]
+
     feat_selector = qd_forest.fit_selector_model(df)
     only_important_features_df = feat_selector.remove_qd(df)
-    result = feat_selector.predict_qd(only_important_features_df)
+    assert list(only_important_features_df.columns) == ["foo"]
 
+    result = feat_selector.predict_qd(only_important_features_df)
     pd.testing.assert_frame_equal(df, result)

--- a/qdscreen/tests/test_core.py
+++ b/qdscreen/tests/test_core.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # the above encoding declaration is needed to have non-ascii characters in this file (anywhere even in comments)
 # from __future__ import unicode_literals  # no, since we want to match the return type of str() which is bytes in py2
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -319,6 +321,8 @@ def test_issue_37_non_categorical():
         qd_screen(df)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6),
+                    reason="This test is known to fail for 3.5 and 2.7, see GH#43")
 def test_issue_40_nan_then_str():
     df = pd.DataFrame({
         "foo": ["1", "2"],

--- a/qdscreen/tests/test_core.py
+++ b/qdscreen/tests/test_core.py
@@ -306,4 +306,27 @@ def test_nans_in_data_sklearn():
 
     selector = QDScreen()
     Xsel = selector.fit_transform(df.to_numpy())
+
     assert Xsel.tolist() == [['A'], ['A'], ['N']]
+
+
+def test_issue_37_non_categorical():
+    df = pd.DataFrame({
+        "nb": [1, 2],
+        "name": ["A", "B"]
+    })
+    with pytest.raises(ValueError, match="Provided dataframe columns contains non-categorical"):
+        qd_screen(df)
+
+
+def test_issue_40_nan_then_str():
+    df = pd.DataFrame({
+        "foo": ["1", "2"],
+        "bar": [np.nan, "B"]
+    })
+    qd_forest = qd_screen(df)
+    feat_selector = qd_forest.fit_selector_model(df)
+    only_important_features_df = feat_selector.remove_qd(df)
+    result = feat_selector.predict_qd(only_important_features_df)
+
+    pd.testing.assert_frame_equal(df, result)


### PR DESCRIPTION
 - Replaced usage of deprecated `scipy_mode`. Fixes #39
 - Fixed `ValueError: invalid literal for int() with base 10` in `predict_qd`. Fixes #40
 - Added input validators to raise human-readable error messages when the input is not correct. Fixes #37
 - Fixed `AttributeError: module 'numpy' has no attribute 'object'.`. Fixes #38

